### PR TITLE
Reverse proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -246,24 +246,18 @@ mu_bulk_bkr_VHOST="BulkMeetUN"
 ## (FIXED VALUE)
 ## port that the MANAGEMENT PLUGIN listens to
 mu_bulk_bkr_MANAGEMENT_INTERNAL_PORT=15672
+
 # --------------------------------- #
 # |        FRONTEND               | #
 # --------------------------------- #
 
-## hostname for which OTHER SERVICES
-## can find the BACKEND service
-mu_fe_HOSTNAME="mu_fe"
-
-## port that the BACKEND service listens to
-# mu_fe_INTERNAL_PORT=3000
-
-## Port to be accessed from HOST machine
-mu_fe_EXPOSED_PORT=80
-
-## Mode that the service runs on. One of:
-##  "prod", "dev"
-mu_fe_MODE="prod"
+mu_fe_HOSTNAME="mu_fe"          # hostname for which OTHER SERVICES can find the FRONTEND service
+mu_fe_INTERNAL_PORT=3000        # port that the FRONTEND service listens to
+mu_fe_EXPOSED_PORT=3000         # Port to be accessed from HOST machine
+mu_fe_MODE="prod"               # Mode that the service runs on. Options: "prod", "dev"
 
 # These environment variables are needed too:
-# mu_main_be_HOSTNAME
-# mu_main_be_INTERNAL_PORT
+# If you are running the whole project, this variables will not be needed,
+# as they will be automatically configured by the docker compose of the whole project.
+# mu_ag_HOSTNAME="localhost"    # Choose localhost in case you are running this service isolated
+# mu_ag_INTERNAL_PORT=4000      # Port that the API Gateway Services listens to

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,13 @@ include:
   # Frontend Superuser
   - path: mu_fe_superuser/docker-compose.yml
     project_directory: mu_fe_superuser/
+
+services:
+  nginx-proxy:
+    image: nginx:latest
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - mu_fe

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,23 @@
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream frontend {
+        server mu_fe:3000;
+    }
+
+    server {
+        listen 80;
+        server_name localhost;
+
+        location / {
+            proxy_pass http://frontend/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request implements the nginx reverse proxy. It is crucial for security purposes.
In order for us to get the project to properly run this way, the had to be some refactoring of the docker compose settings of the frontend, reflected in the git submodule update of it in two commits.
Now the project is accesed through the port 80, but not because the frontend exposes it. In it's place, nginx redirects the traffic of port 80 towards the 3000 port of the frontend